### PR TITLE
Fix hyperlink and other issue

### DIFF
--- a/Graduate/Readme.md
+++ b/Graduate/Readme.md
@@ -9,6 +9,8 @@
 
 有关春招、秋招或其他求职信息，请移步 [Job Hunting](../Job-Hunting/) 板块。
 
+目前暂无实际内容，出国申请 Master 部分是一个目录结构的示例，欢迎贡献。
+
 ## Contribution Guide
 
 ### Directory Structure

--- a/Graduate/Readme.md
+++ b/Graduate/Readme.md
@@ -4,7 +4,7 @@
 
 - 国内保研的相关资料
 - 国内直博的相关资料
-- [出国申请 Master 的相关资料](Overseas/index.md)
+- [出国申请 Master 的相关资料](Overseas-Master/index.md)
 - 出国申请 PhD 的相关资料
 
 有关春招、秋招或其他求职信息，请移步 [Job Hunting](../Job-Hunting/) 板块。

--- a/Tutorial/Readme.md
+++ b/Tutorial/Readme.md
@@ -2,9 +2,9 @@
 
 ## Index
 
-- [企业就职的路径规划与攻略](Profession/index.md)
-- [获取教职的路径规划与攻略](Faculty/index.md)
-- [从政的路径规划与攻略](GOV/index.md)
+- 企业就职的路径规划与攻略
+- 获取教职的路径规划与攻略
+- 从政的路径规划与攻略
 
 ## Contribution Guide
 

--- a/Tutorial/Readme.md
+++ b/Tutorial/Readme.md
@@ -6,6 +6,8 @@
 - 获取教职的路径规划与攻略
 - 从政的路径规划与攻略
 
+本部分暂无内容，欢迎贡献。
+
 ## Contribution Guide
 
 ### Directory Structure


### PR DESCRIPTION
1. 修复了 Overseas-Master 的一个失效超链接
2. 删除了 tutorial 部分指向 index.md 的链接，因为那些 table of resources 暂时都还是空的，留着超链接可能会误导人点进去看，浪费时间
3. 对于整个模块都没有资料的部分添加了“暂无内容，欢迎贡献”的说明